### PR TITLE
Azure.Identityのバージョンを1.11.4から1.13.2に更新

### DIFF
--- a/src/MachineLog.Collector/MachineLog.Collector.csproj
+++ b/src/MachineLog.Collector/MachineLog.Collector.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />


### PR DESCRIPTION
# 変更内容
- Azure.Identityパッケージのバージョンを1.11.4から1.13.2に更新

# 変更理由
- セキュリティ修正と機能改善を含む最新バージョンへの更新
- 依存関係の最新化によるプロジェクトの安定性向上

# 確認事項
- ビルドが正常に完了することを確認済み