### PR TITLE
fix: Terraformリソースグループ名の変数化とEntra ID権限の問題解決

### DIFF
--- a/src/MachineLog.Infrastructure/environments/dev/main.tf
+++ b/src/MachineLog.Infrastructure/environments/dev/main.tf
@@ -30,8 +30,10 @@ provider "azuread" {}
 data "azurerm_client_config" "current" {}
 
 locals {
-  environment = "dev"
-  location    = "japaneast"
+  environment         = "dev"
+  location            = "japaneast"
+  resource_group_name = "rg-iothub"
+  project_name        = "iothub"
   tags = {
     Environment = "Development"
     Project     = "MachineLog"
@@ -41,7 +43,7 @@ locals {
 }
 
 resource "azurerm_resource_group" "this" {
-  name     = "rg-machinelog-${local.environment}"
+  name     = "${local.resource_group_name}-${local.environment}"
   location = local.location
   tags     = local.tags
 }
@@ -71,10 +73,10 @@ module "azure_storage" {
 module "entra_id" {
   source = "../../modules/entra-id"
 
-  application_name     = "MachineLog"
+  application_name     = local.project_name
   environment          = local.environment
-  homepage_url         = "https://app-machinelog-${local.environment}.azurewebsites.net"
-  redirect_uris        = ["https://app-machinelog-${local.environment}.azurewebsites.net/signin-oidc"]
+  homepage_url         = "https://app-${local.project_name}-${local.environment}.azurewebsites.net"
+  redirect_uris        = ["https://app-${local.project_name}-${local.environment}.azurewebsites.net/signin-oidc"]
   create_client_secret = true
 }
 

--- a/src/MachineLog.Infrastructure/environments/dev/terraform.tfvars
+++ b/src/MachineLog.Infrastructure/environments/dev/terraform.tfvars
@@ -1,0 +1,26 @@
+# リソースグループ設定
+resource_group_name = "rg-iothub-demo"
+location            = "japaneast"
+environment         = "dev"
+
+# Log Analytics設定
+log_analytics_sku     = "PerGB2018"
+log_retention_in_days = 30
+
+# ストレージアカウント設定
+storage_account_tier     = "Standard"
+storage_replication_type = "LRS"
+
+# App Service設定
+app_service_plan_sku = "B1"
+
+# アラート設定
+alert_email_address = "admin@example.com"
+
+# タグ設定
+tags = {
+  Environment = "Development"
+  Project     = "IoTHub Demo"
+  Owner       = "DevOps Team"
+  ManagedBy   = "Terraform"
+}


### PR DESCRIPTION
## 修正内容

1. リソースグループ名を変数として使用するように修正
   - locals ブロックに resource_group_name と project_name 変数を追加
   - リソースグループの name 属性を変数を使用するように変更
   - Entra IDモジュールのアプリケーション名とURLも変数を使用するように修正

2. 変数ファイル（terraform.tfvars）を作成して、正しい変数値を指定

## Entra ID権限の問題解決方法

Terraformの実行に使用しているアカウントに、Entra IDアプリケーションを作成する権限を付与するには、以下の手順を実行してください：

1. Azure portalにログイン
2. Azure Active Directory > アプリの登録 > すべてのアプリケーション に移動
3. Terraformの実行に使用しているサービスプリンシパルを選択
4. API権限 > 権限の追加 を選択
5. Microsoft Graph > アプリケーション権限 を選択
6. 以下の権限を追加：
   - Application.ReadWrite.All
   - Directory.ReadWrite.All
7. 管理者の同意を与える をクリック