### PR TITLE
Fix: Log Analytics Saved Search function_parameters syntax

### DIFF
--- a/src/MachineLog.Infrastructure/modules/azure-monitor/main.tf
+++ b/src/MachineLog.Infrastructure/modules/azure-monitor/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_log_analytics_saved_search" "error_logs" {
   display_name               = "エラーログ"
   query                      = "MachineLog_CL | where Severity == 'Error' | order by TimeGenerated desc"
   function_alias             = "ErrorLogs"
-  function_parameters        = ["timespan"]
+  function_parameters        = ["timespan:string='P1D'"]
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
 }
 

--- a/src/MachineLog.Infrastructure/modules/azure-monitor/main.tf
+++ b/src/MachineLog.Infrastructure/modules/azure-monitor/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_log_analytics_saved_search" "error_logs" {
   display_name               = "エラーログ"
   query                      = "MachineLog_CL | where Severity == 'Error' | order by TimeGenerated desc"
   function_alias             = "ErrorLogs"
-  function_parameters        = ["timespan:timespan=P1D"]
+  function_parameters        = ["timespan"]
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
 }
 


### PR DESCRIPTION
## 問題の原因
エラーメッセージ「Invalid function parameters string」が示すように、function_parameters の構文が間違っていました。元の値は Azure Log Analytics の Saved Search で使用される正しい構文ではありませんでした。

## 修正内容
function_parameters の値を ["timespan"] に変更しました。これは単純なパラメータ名のリストとして定義され、Azure Log Analytics の Saved Search の正しい構文に準拠しています。